### PR TITLE
Fix a case where the secret cannot not be restored

### DIFF
--- a/js/secrets.js
+++ b/js/secrets.js
@@ -222,6 +222,9 @@ exports.share = function(secret, numShares, threshold, padLength, withoutPrefix)
 	if(typeof padLength !== 'number' || padLength%1 !== 0 ){
 		throw new Error('Zero-pad length must be an integer greater than 1.');
 	}
+    if(numShares < threshold){
+        throw new Error('The number of shares must not be lower than the threshold.');
+    }
 	
 	if(config.unsafePRNG){
 		warn();


### PR DESCRIPTION
Fix #2 

If the number of shares is lower than the
threshold, the generated shares cannot be used
to restore the secret. Throw an error if that's
the case.